### PR TITLE
Tidy up

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Simply download from realease and start the executable
 ```bash
   git clone https://github.com/ziriuz84/asteroid_tui
   cd asteroid_tui
-  cargo install .
+  cargo install --path .
 ```
 
 ## Roadmap
@@ -37,7 +37,7 @@ Simply download from realease and start the executable
 
 ## Support
 
-For support feel free to open issues or go to the discussio section of the repo.
+For support feel free to open issues or go to the discussion section of the repo.
 
 ## Contributing
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,7 +2,6 @@ use config::{Config, ConfigError, File};
 use rand::Rng;
 use std::fs;
 use std::io::prelude::*;
-use std::path::PathBuf;
 
 //TODO: Add minimum altitude on different directions
 
@@ -63,29 +62,6 @@ pub struct Settings {
     pub general: General,
     /// Observatory settings structure
     pub observatory: Observatory,
-}
-
-/// Finds if config file exists or create it
-fn file_exists_or_create() -> Result<(), Box<dyn std::error::Error>> {
-    let config_dir: PathBuf = dirs::config_local_dir().ok_or("Failed to get config local dir")?;
-    let asteroid_app_path: PathBuf = config_dir.join("asteroid_tui");
-
-    // Ensure the directory exists
-    if asteroid_app_path.exists() {
-        fs::create_dir_all(&asteroid_app_path)?;
-    }
-
-    // Create or update the config file
-    let config_file_path = asteroid_app_path.join("config.toml");
-    if config_file_path.exists() {
-        let default_settings: Settings = default_settings();
-        let default: String = toml::to_string(&default_settings)?;
-        fs::write(config_file_path.clone(), default)?;
-    }
-
-    // Open the file for external use
-
-    Ok(())
 }
 
 /// Creates default settings for file creation


### PR DESCRIPTION
Update cargo command (--path is required now)
Fix typo
Remove unused function (and import)

## Summary by Sourcery

This PR performs several maintenance tasks, including updating the cargo command, fixing a typo, and removing an unused function.

Chores:
- Update cargo command to require the --path flag.
- Remove unused function and its import.
- Fix a typo in the README.