### PR TITLE
ci: align Jenkins pipeline with server setup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label 'linux' }
+    agent { label 'master' }
 
     environment {
         CARGO_TERM_COLOR = 'always'
@@ -62,13 +62,13 @@ pipeline {
             }
         }
 
-        stage('Quality Gate') {
-            steps {
-                timeout(time: 5, unit: 'MINUTES') {
-                    waitForQualityGate abortPipeline: true
-                }
-            }
-        }
+        // stage('Quality Gate') {
+        //     steps {
+        //         timeout(time: 5, unit: 'MINUTES') {
+        //             waitForQualityGate abortPipeline: true
+        //         }
+        //     }
+        // }
 
         stage('Package Release') {
             when { buildingTag() }
@@ -92,7 +92,7 @@ pipeline {
         stage('GitHub Release') {
             when { buildingTag() }
             steps {
-                withCredentials([string(credentialsId: 'github-token', variable: 'GH_TOKEN')]) {
+                withCredentials([string(credentialsId: 'github-credentials', variable: 'GH_TOKEN')]) {
                     sh '''
                         gh release create "${TAG_NAME}" \
                             --repo "${GITHUB_REPO}" \


### PR DESCRIPTION
Use master agent label for scheduling, github-credentials for releases, and disable the quality gate until SonarQube webhook is configured.

## Summary by Sourcery

Align the Jenkins pipeline configuration with the current server and credential setup.

CI:
- Change the Jenkins agent label from 'linux' to 'master' for pipeline execution.
- Temporarily disable the SonarQube quality gate stage in the Jenkins pipeline.
- Update GitHub release credentials to use the 'github-credentials' secret instead of 'github-token'.