### PR TITLE
ci: run pipeline on any available agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label 'master' }
+    agent any
 
     environment {
         CARGO_TERM_COLOR = 'always'


### PR DESCRIPTION
Replace master label constraint with agent any so builds schedule without requiring a specific node label.

## Summary by Sourcery

CI:
- Update Jenkins pipeline configuration to use a generic 'any' agent rather than the 'master' labeled node.